### PR TITLE
feat: open cash box without side cut effect

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
@@ -206,6 +206,20 @@ public class EscPosPrinter extends EscPosPrinterSize {
         this.printer.openCashBox();
         return this;
     }
+    
+    /**
+     * Open cash box 
+     *
+     * @return Fluent interface
+     */
+    public EscPosPrinter openCashBox() throws EscPosConnectionException, EscPosParserException, EscPosEncodingException, EscPosBarcodeException {
+        if (this.printer == null || this.printerNbrCharactersPerLine == 0) {
+            return this;
+        }
+        this.printer.openCashBox();
+        return this;
+    }
+    
 
     /**
      * @return Charset encoding


### PR DESCRIPTION
Create new open cash box function with out side cut effect. 

The current method will cut the paper before open the cash box, which is violate SOLID principle. 